### PR TITLE
feat: Add DISABLE_THUMBNAILS and DISABLE_DATABASE environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,13 @@ NANOBANANA_MODEL=auto
 # Default: ~/nanobanana-images
 # IMAGE_OUTPUT_DIR=/path/to/output
 
+# Storage Options (optional)
+# Set to true to disable thumbnail generation (returns full images instead)
+# DISABLE_THUMBNAILS=false
+
+# Set to true to disable the images.db tracking database
+# DISABLE_DATABASE=false
+
 # Gemini 3 Pro Model Settings (optional, only applies when using Pro model)
 # GEMINI_PRO_THINKING_LEVEL=high  # low, high
 # GEMINI_PRO_ENABLE_GROUNDING=true  # Enable Google Search grounding

--- a/README.md
+++ b/README.md
@@ -311,6 +311,10 @@ NANOBANANA_MODEL=auto  # Options: flash, pro, auto (default: auto)
 IMAGE_OUTPUT_DIR=/path/to/image/directory  # Default: ~/nanobanana-images
 LOG_LEVEL=INFO                             # DEBUG, INFO, WARNING, ERROR
 LOG_FORMAT=standard                        # standard, json, detailed
+
+# Storage Options (optional)
+DISABLE_THUMBNAILS=false  # Set to true to disable thumbnail generation
+DISABLE_DATABASE=false    # Set to true to disable images.db tracking database
 ```
 
 ## 🐛 Troubleshooting

--- a/nanobanana_mcp_server/config/settings.py
+++ b/nanobanana_mcp_server/config/settings.py
@@ -38,6 +38,8 @@ class ServerConfig:
     mask_error_details: bool = False
     max_concurrent_requests: int = 10
     image_output_dir: str = ""
+    disable_thumbnails: bool = False
+    disable_database: bool = False
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
@@ -58,6 +60,10 @@ class ServerConfig:
         output_path = Path(output_dir).resolve()
         output_path.mkdir(parents=True, exist_ok=True)
 
+        # Parse boolean options for disabling thumbnails and database
+        disable_thumbnails = os.getenv("DISABLE_THUMBNAILS", "false").lower() in ("true", "1", "yes")
+        disable_database = os.getenv("DISABLE_DATABASE", "false").lower() in ("true", "1", "yes")
+
         return cls(
             gemini_api_key=api_key,
             transport=os.getenv("FASTMCP_TRANSPORT", "stdio"),
@@ -65,6 +71,8 @@ class ServerConfig:
             port=int(os.getenv("FASTMCP_PORT", "9000")),
             mask_error_details=os.getenv("FASTMCP_MASK_ERRORS", "false").lower() == "true",
             image_output_dir=str(output_path),
+            disable_thumbnails=disable_thumbnails,
+            disable_database=disable_database,
         )
 
 

--- a/nanobanana_mcp_server/services/__init__.py
+++ b/nanobanana_mcp_server/services/__init__.py
@@ -61,13 +61,17 @@ def initialize_services(server_config: ServerConfig, gemini_config: GeminiConfig
 
     # Initialize enhanced services for workflows.md implementation
     out_dir = server_config.image_output_dir
-    _image_database_service = ImageDatabaseService(db_path=os.path.join(out_dir, "images.db"))
+    _image_database_service = ImageDatabaseService(
+        db_path=os.path.join(out_dir, "images.db"),
+        disabled=server_config.disable_database
+    )
     # Use a subdirectory within the configured output directory for temp images
     temp_images_dir = os.path.join(out_dir, "temp_images")
     _image_storage_service = ImageStorageService(gemini_config, temp_images_dir)
     _files_api_service = FilesAPIService(_gemini_client, _image_database_service)
     _enhanced_image_service = EnhancedImageService(
-        _gemini_client, _files_api_service, _image_database_service, gemini_config, out_dir
+        _gemini_client, _files_api_service, _image_database_service, gemini_config, out_dir,
+        server_config=server_config
     )
     _maintenance_service = MaintenanceService(_files_api_service, _image_database_service, out_dir)
 


### PR DESCRIPTION
## Summary

This PR adds two new optional environment variables that allow users to control thumbnail generation and database tracking:

- **`DISABLE_THUMBNAILS=true`**: Skips thumbnail generation, returns full images directly instead of thumbnails. Useful for users who don't need thumbnail previews and want to reduce disk space usage.

- **`DISABLE_DATABASE=true`**: Disables the `images.db` SQLite database that tracks image metadata and Files API relationships. All database operations become no-ops when disabled. Useful for users who don't need image tracking/relationship features.

## Changes

| File | Description |
|------|-------------|
| `config/settings.py` | Added `disable_thumbnails` and `disable_database` fields to `ServerConfig`, parsed from environment variables |
| `services/image_database_service.py` | Added `disabled` parameter to `__init__`, all methods return early with sensible defaults when disabled |
| `services/enhanced_image_service.py` | Added `server_config` parameter, conditionally skips thumbnail creation based on `disable_thumbnails` |
| `services/__init__.py` | Pass `disabled` flag and `server_config` to services during initialization |
| `README.md` | Document new environment variables |
| `.env.example` | Add commented examples for new options |

## Example Usage

```json
{
  "mcpServers": {
    "nanobanana": {
      "command": "uvx",
      "args": ["nanobanana-mcp-server@latest"],
      "env": {
        "GEMINI_API_KEY": "your-key",
        "DISABLE_THUMBNAILS": "true",
        "DISABLE_DATABASE": "true"
      }
    }
  }
}
```

## Test plan

- [ ] Verify image generation works with default settings (both disabled=false)
- [ ] Test with `DISABLE_THUMBNAILS=true` - full images should be returned instead of thumbnails
- [ ] Test with `DISABLE_DATABASE=true` - no `images.db` file should be created
- [ ] Test with both options enabled together
- [ ] Verify documentation is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)