### PR TITLE
fix: Route Pro model requests to ProImageService and fix API parameters

### DIFF
--- a/nanobanana_mcp_server/config/settings.py
+++ b/nanobanana_mcp_server/config/settings.py
@@ -66,7 +66,9 @@ class ServerConfig:
 
         api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
         gcp_project = os.getenv("GCP_PROJECT_ID") or os.getenv("GOOGLE_CLOUD_PROJECT")
-        gcp_region = os.getenv("GCP_REGION") or os.getenv("GOOGLE_CLOUD_LOCATION") or "us-central1"
+        # Default to "global" for gemini-3-pro-image-preview compatibility
+        # Users can override via GCP_REGION or GOOGLE_CLOUD_LOCATION env vars
+        gcp_region = os.getenv("GCP_REGION") or os.getenv("GOOGLE_CLOUD_LOCATION") or "global"
 
         # Validation logic
         if auth_method == AuthMethod.API_KEY:

--- a/nanobanana_mcp_server/services/pro_image_service.py
+++ b/nanobanana_mcp_server/services/pro_image_service.py
@@ -129,17 +129,14 @@ class ProImageService:
                     )
 
                     # Build generation config for Pro model
+                    # Note: thinking_level is NOT supported by gemini-3-pro-image-preview
+                    # Resolution is passed and mapped to image_size in gemini_client
                     gen_config = {
-                        "thinking_level": thinking_level.value,
+                        "resolution": resolution,  # Will be mapped to image_size (1K, 2K, 4K)
                     }
 
-                    # Add Pro-specific parameters
-                    if self.config.supports_media_resolution:
-                        gen_config["media_resolution"] = media_resolution.value
-
-                    # Note: Grounding is controlled via prompt/system instruction
-                    # The API may not expose enable_grounding as a direct parameter
-                    # depending on SDK version
+                    # Grounding is controlled via prompt/system instruction
+                    # not as a direct API parameter
 
                     response = self.gemini_client.generate_content(
                         contents,
@@ -217,8 +214,8 @@ class ProImageService:
 
                 except Exception as e:
                     self.logger.error(f"Failed to generate Pro image {i + 1}: {e}")
-                    # Continue with other images rather than failing completely
-                    continue
+                    # Re-raise to see the actual error
+                    raise
 
             progress.update(100, f"Generated {len(all_images)} high-quality image(s)")
 

--- a/nanobanana_mcp_server/tools/generate_image.py
+++ b/nanobanana_mcp_server/tools/generate_image.py
@@ -260,14 +260,32 @@ def register_generate_image_tool(server: FastMCP):
 
                 # Generate images following workflows.md pattern:
                 # M->G->FS->F->D (save full-res, create thumbnail, upload to Files API, track in DB)
-                thumbnail_images, metadata = enhanced_image_service.generate_images(
-                    prompt=prompt,
-                    n=n,
-                    negative_prompt=negative_prompt,
-                    system_instruction=system_instruction,
-                    input_images=input_images,
-                    aspect_ratio=aspect_ratio,
-                )
+                # Route to correct service based on selected model tier
+                if selected_tier == ModelTier.PRO:
+                    # Use Pro service for high-quality generation
+                    logger.info(f"Using PRO model: {model_info['model_id']}")
+                    thumbnail_images, metadata = selected_service.generate_images(
+                        prompt=prompt,
+                        n=n,
+                        resolution=resolution,
+                        thinking_level=ThinkingLevel(thinking_level) if thinking_level else None,
+                        enable_grounding=enable_grounding,
+                        negative_prompt=negative_prompt,
+                        system_instruction=system_instruction,
+                        input_images=input_images,
+                        use_storage=True,
+                    )
+                else:
+                    # Use Flash service (via enhanced_image_service) for speed
+                    logger.info(f"Using FLASH model: {model_info['model_id']}")
+                    thumbnail_images, metadata = enhanced_image_service.generate_images(
+                        prompt=prompt,
+                        n=n,
+                        negative_prompt=negative_prompt,
+                        system_instruction=system_instruction,
+                        input_images=input_images,
+                        aspect_ratio=aspect_ratio,
+                    )
 
             # Create response with file paths and thumbnails
             if metadata:


### PR DESCRIPTION
## Summary

The Pro model (`gemini-3-pro-image-preview`) was not working. This PR fixes it so both Flash (2.5) and Pro (3) models work correctly.

## Problems Fixed

1. **Routing bug**: `generate_image.py` always routed to `enhanced_image_service` (Flash) regardless of selected model tier
2. **Invalid parameter**: `thinking_level` was being passed to `GenerateContentConfig` but this parameter is not supported by the API
3. **Wrong response modalities**: Was `["Image"]` but Pro model requires `["TEXT", "IMAGE"]`
4. **Wrong default region**: Was `us-central1` but Pro model requires `global` region

## Changes

| File | Change |
|------|--------|
| `settings.py` | Default region → `global` (env var override still works) |
| `gemini_client.py` | Fixed `response_modalities`, added `image_size` mapping, removed unsupported `thinking_level` |
| `pro_image_service.py` | Pass `resolution` instead of `thinking_level` |
| `generate_image.py` | Route PRO tier → `selected_service`, FLASH → `enhanced_image_service` |

## Testing

Tested with `gemini-3-pro-image-preview` generating 4K images (5504x3072) successfully on Vertex AI.

Co-authored with Claude