### PR TITLE
Fix errors with image_size and output_mime_type in ImageConfig object

### DIFF
--- a/nanobanana_mcp_server/services/gemini_client.py
+++ b/nanobanana_mcp_server/services/gemini_client.py
@@ -150,9 +150,6 @@ class GeminiClient:
                     image_config_kwargs["image_size"] = image_size
                     self.logger.info(f"Setting image_size={image_size} for resolution={resolution}")
 
-                # Add output mime type
-                image_config_kwargs["output_mime_type"] = "image/png"
-
                 if image_config_kwargs:
                     config_kwargs["image_config"] = gx.ImageConfig(**image_config_kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "fastmcp>=2.11.0",
-    "google-genai>=1.41.0",
+    "google-genai>=1.57.0",
     "pillow>=10.4.0",
     "python-dotenv>=1.0.1",
     "pydantic>=2.0.0",
@@ -147,7 +147,7 @@ python_files = ["test_*.py", "*_test.py"]
 python_functions = ["test_*"]
 markers = [
     "unit: Unit tests",
-    "integration: Integration tests", 
+    "integration: Integration tests",
     "slow: Slow running tests",
     "network: Tests requiring network access",
 ]

--- a/tests/test_aspect_ratio.py
+++ b/tests/test_aspect_ratio.py
@@ -105,13 +105,12 @@ class TestGeminiClientAspectRatio:
                 aspect_ratio="16:9"
             )
 
-            # Verify ImageConfig was called with aspect_ratio and output_mime_type
+            # Verify ImageConfig was called with aspect_ratio
             call_kwargs = mock_gx.ImageConfig.call_args[1]
             assert call_kwargs.get('aspect_ratio') == "16:9"
-            assert call_kwargs.get('output_mime_type') == "image/png"
 
     def test_aspect_ratio_none_creates_image_config_without_aspect_ratio(self, gemini_client):
-        """Test that aspect_ratio=None creates ImageConfig with just output_mime_type."""
+        """Test that aspect_ratio=None creates ImageConfig without aspect_ratio."""
         with patch('nanobanana_mcp_server.services.gemini_client.gx') as mock_gx:
             mock_gx.GenerateContentConfig = Mock()
             mock_gx.ImageConfig = Mock()
@@ -119,11 +118,10 @@ class TestGeminiClientAspectRatio:
             # Call without aspect_ratio
             gemini_client.generate_content(contents=["test prompt"])
 
-            # Verify ImageConfig was called with output_mime_type but no aspect_ratio
+            # Verify ImageConfig was called without aspect_ratio
             mock_gx.ImageConfig.assert_called_once()
             call_kwargs = mock_gx.ImageConfig.call_args[1]
             assert 'aspect_ratio' not in call_kwargs
-            assert call_kwargs.get('output_mime_type') == "image/png"
 
     def test_config_conflict_warning(self, gemini_client, caplog):
         """Test warning when both config dict and aspect_ratio are provided."""

--- a/uv.lock
+++ b/uv.lock
@@ -1109,7 +1109,7 @@ wheels = [
 
 [[package]]
 name = "nanobanana-mcp-server"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
This fix address the issue here: https://github.com/zhongweili/nanobanana-mcp-server/issues/12

1) Upgrade the version requirement for google-genai, since "image_size" is not in ImageConfig in google-genai==1.41.0
2) Removed output_mime_type field, since that field is not in ImageConfig
3) Updated the unit tests w.r.t. (2)