### PR TITLE
fix: log configured default NanoBanana model behavior

### DIFF
--- a/nanobanana_mcp_server/server.py
+++ b/nanobanana_mcp_server/server.py
@@ -8,12 +8,40 @@ capabilities through Google's Gemini 2.5 Flash Image model.
 
 import sys
 import os
-from .config.settings import ServerConfig, GeminiConfig
+import logging
+
+from .config.settings import (
+    FlashImageConfig,
+    GeminiConfig,
+    ModelSelectionConfig,
+    ModelTier,
+    NanoBanana2Config,
+    ProImageConfig,
+    ServerConfig,
+)
 from .core.server import NanoBananaMCP
 from .core.exceptions import ConfigurationError
 from .utils.logging_utils import setup_logging
 from . import services
-import logging
+
+
+def _default_model_summary() -> str:
+    """Return a truthful startup summary of the configured default model behavior."""
+    selection = ModelSelectionConfig.from_env()
+
+    if selection.default_tier == ModelTier.FLASH:
+        return f"{selection.default_tier.value} ({FlashImageConfig().model_name})"
+    if selection.default_tier == ModelTier.PRO:
+        return f"{selection.default_tier.value} ({ProImageConfig().model_name})"
+    if selection.default_tier == ModelTier.NB2:
+        return f"{selection.default_tier.value} ({NanoBanana2Config().model_name})"
+
+    # AUTO is a routing strategy, not a single concrete model.
+    return (
+        "auto (smart selection across "
+        f"{NanoBanana2Config().model_name}, {ProImageConfig().model_name}, "
+        f"and {FlashImageConfig().model_name})"
+    )
 
 
 def create_app():
@@ -38,7 +66,7 @@ def create_app():
         gemini_config = GeminiConfig()
 
         logger.info(f"Server transport: {server_config.transport}")
-        logger.info(f"Gemini model: {gemini_config.model_name}")
+        logger.info(f"Default model behavior: {_default_model_summary()}")
 
         # Initialize services first
         services.initialize_services(server_config, gemini_config)
@@ -79,7 +107,7 @@ def create_wrapper_app() -> NanoBananaMCP:
         gemini_config = GeminiConfig()
 
         logger.info(f"Server transport: {server_config.transport}")
-        logger.info(f"Gemini model: {gemini_config.model_name}")
+        logger.info(f"Default model behavior: {_default_model_summary()}")
 
         # Initialize services first
         services.initialize_services(server_config, gemini_config)

--- a/tests/test_startup_model_summary.py
+++ b/tests/test_startup_model_summary.py
@@ -1,0 +1,28 @@
+import os
+
+from nanobanana_mcp_server.server import _default_model_summary
+
+
+def test_default_model_summary_auto(monkeypatch):
+    monkeypatch.delenv("NANOBANANA_MODEL", raising=False)
+    summary = _default_model_summary()
+    assert summary == (
+        "auto (smart selection across "
+        "gemini-3.1-flash-image-preview, gemini-3-pro-image-preview, "
+        "and gemini-2.5-flash-image)"
+    )
+
+
+def test_default_model_summary_nb2(monkeypatch):
+    monkeypatch.setenv("NANOBANANA_MODEL", "nb2")
+    assert _default_model_summary() == "nb2 (gemini-3.1-flash-image-preview)"
+
+
+def test_default_model_summary_pro(monkeypatch):
+    monkeypatch.setenv("NANOBANANA_MODEL", "pro")
+    assert _default_model_summary() == "pro (gemini-3-pro-image-preview)"
+
+
+def test_default_model_summary_flash(monkeypatch):
+    monkeypatch.setenv("NANOBANANA_MODEL", "flash")
+    assert _default_model_summary() == "flash (gemini-2.5-flash-image)"


### PR DESCRIPTION
## Summary
- replace the hard-coded startup log that always reported `gemini-2.5-flash-image`
- log the configured default model behavior based on `NANOBANANA_MODEL` instead
- add unit coverage for flash, nb2, pro, and auto summaries

## Root cause
`server.py` logged `GeminiConfig().model_name`, which always points to the legacy flash config and ignored the multi-model routing configuration.

## Validation
- `.venv/bin/python -m pytest tests/test_startup_model_summary.py -q`
- manual startup verification with `NANOBANANA_MODEL=nb2` shows: `Default model behavior: nb2 (gemini-3.1-flash-image-preview)`
- cross-reviewed with Gemini CLI before opening this PR
