### PR TITLE
docs(vertex-ai): default GCP_REGION to `global`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,11 @@ GEMINI_API_KEY=your_api_key_here
 GCP_PROJECT_ID=your-project-id
 # GOOGLE_CLOUD_PROJECT=your-project-id  # Alternative
 
-# Google Cloud Region (Default: us-central1)
-GCP_REGION=us-central1
-# GOOGLE_CLOUD_LOCATION=us-central1  # Alternative
+# Google Cloud Region (Default: global)
+# Use "global" for gemini-3-pro-image-preview and gemini-3.1-flash-image-preview (NB2).
+# Regional endpoints like "us-central1" only work with legacy gemini-2.5-flash-image.
+GCP_REGION=global
+# GOOGLE_CLOUD_LOCATION=global  # Alternative
 
 # ============================================================
 # Model Settings

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Required environment variables:
 
 - `NANOBANANA_AUTH_METHOD=vertex_ai` (or `auto`)
 - `GCP_PROJECT_ID=your-project-id`
-- `GCP_REGION=us-central1` (default)
+- `GCP_REGION=global` (default; required for Gemini 3 Pro Image and NB2. Use `us-central1` only for the legacy 2.5 Flash Image model.)
 
 **Prerequisites**:
 
@@ -135,7 +135,7 @@ To authenticate with Google Cloud Application Default Credentials (instead of an
       "env": {
         "NANOBANANA_AUTH_METHOD": "vertex_ai",
         "GCP_PROJECT_ID": "your-project-id",
-        "GCP_REGION": "us-central1"
+        "GCP_REGION": "global"
       }
     }
   }
@@ -470,7 +470,7 @@ GEMINI_API_KEY=your-gemini-api-key-here
 # Method 2: Vertex AI (Google Cloud)
 NANOBANANA_AUTH_METHOD=vertex_ai
 GCP_PROJECT_ID=your-project-id
-GCP_REGION=us-central1
+GCP_REGION=global  # Required for gemini-3-pro-image-preview and NB2; use "us-central1" only for legacy 2.5 Flash Image
 
 # Model Selection (optional)
 NANOBANANA_MODEL=auto  # Options: flash, nb2, pro, auto (default: auto → nb2)

--- a/nanobanana_mcp_server/config/settings.py
+++ b/nanobanana_mcp_server/config/settings.py
@@ -56,7 +56,7 @@ class ServerConfig:
     return_full_image: bool = False
     auth_method: AuthMethod = AuthMethod.AUTO
     gcp_project_id: str | None = None
-    gcp_region: str = "us-central1"
+    gcp_region: str = "global"
     gemini_base_url: str | None = None
 
     @classmethod


### PR DESCRIPTION
## Summary

- The runtime already defaults `gcp_region` to `"global"` in `config/settings.py:from_env()`, but `.env.example`, the three Vertex AI snippets in `README.md`, and the `ServerConfig` dataclass field default still said `us-central1`.
- `gemini-3-pro-image-preview` and the current default `gemini-3.1-flash-image-preview` (NB2) both require the `global` endpoint on Vertex AI — regional endpoints like `us-central1` only work with the legacy `gemini-2.5-flash-image` model.
- Copy-pasting from the README therefore produced a broken Vertex AI setup for new users. This PR finishes the migration so the user-facing examples match the runtime default.

## Changes

- `.env.example` — switch active `GCP_REGION` to `global` and explain when `us-central1` still applies.
- `README.md` — update all three Vertex AI examples (quick-start, Claude Desktop ADC config, Environment Variables) to `global`.
- `nanobanana_mcp_server/config/settings.py` — align the `ServerConfig.gcp_region` dataclass default with what `from_env()` actually produces.

## Test plan

- [x] `uv run pytest tests/test_auth.py -q` — auth tests still pass (they exercise explicit `us-central1`, verifying forwarding, not the default).
- [x] `uv run ruff check nanobanana_mcp_server/config/settings.py` — clean.

Fixes #28.