### PR TITLE
fix(vertex-ai): set request timeout to prevent indefinite hangs

### DIFF
--- a/nanobanana_mcp_server/services/gemini_client.py
+++ b/nanobanana_mcp_server/services/gemini_client.py
@@ -35,19 +35,25 @@ class GeminiClient:
     def client(self) -> genai.Client:
         """Lazy initialization of Gemini client."""
         if self._client is None:
-            # Build http_options for custom base URL if configured
-            http_options = None
+            http_options = {}
             if self.config.gemini_base_url:
-                http_options = {"base_url": self.config.gemini_base_url}
+                http_options["base_url"] = self.config.gemini_base_url
                 safe_url = self._get_safe_base_url_for_log(self.config.gemini_base_url)
                 self.logger.info(f"Using custom base URL: {safe_url}")
+
+            # Set request timeout (in milliseconds) to prevent indefinite hangs.
+            # Without this, httpx receives timeout=None which disables timeouts entirely.
+            timeout_seconds = getattr(self.gemini_config, "request_timeout", 60)
+            http_options["timeout"] = timeout_seconds * 1000
+            self.logger.debug(f"Request timeout: {timeout_seconds}s")
 
             if self.config.auth_method == AuthMethod.API_KEY:
                 if not self.config.gemini_api_key:
                     raise AuthenticationError("API key is required for API_KEY auth method")
-                client_kwargs = {"api_key": self.config.gemini_api_key}
-                if http_options:
-                    client_kwargs["http_options"] = http_options
+                client_kwargs = {
+                    "api_key": self.config.gemini_api_key,
+                    "http_options": http_options,
+                }
                 self._client = genai.Client(**client_kwargs)
                 self._log_auth_method("API Key (Developer API)")
             else:  # VERTEX_AI
@@ -55,9 +61,8 @@ class GeminiClient:
                     "vertexai": True,
                     "project": self.config.gcp_project_id,
                     "location": self.config.gcp_region,
+                    "http_options": http_options,
                 }
-                if http_options:
-                    client_kwargs["http_options"] = http_options
                 self._client = genai.Client(**client_kwargs)
                 self._log_auth_method(f"ADC (Vertex AI - {self.config.gcp_region})")
         return self._client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nanobanana-mcp-server"
-version = "0.4.4"
+version = "0.4.5"
 description = "A production-ready MCP server for AI-powered image generation using Gemini 3.1 Flash Image (Nano Banana 2, default), Gemini 3 Pro Image, and Gemini 2.5 Flash Image with intelligent model selection"
 authors = [
     { name = "zhongwei", email = "lizhongwei.nkcs@gmail.com" }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -70,7 +70,10 @@ class TestGeminiClientAuth:
         # Access client property to trigger initialization
         _ = client.client
 
-        mock_client_cls.assert_called_with(api_key="test-key")
+        mock_client_cls.assert_called_with(
+            api_key="test-key",
+            http_options={"timeout": 60000},
+        )
 
     @patch("google.genai.Client")
     def test_vertex_ai_client_creation(self, mock_client_cls):
@@ -88,7 +91,10 @@ class TestGeminiClientAuth:
         _ = client.client
 
         mock_client_cls.assert_called_with(
-            vertexai=True, project="test-project", location="us-central1"
+            vertexai=True,
+            project="test-project",
+            location="us-central1",
+            http_options={"timeout": 60000},
         )
 
     @patch("google.genai.Client")
@@ -107,6 +113,9 @@ class TestGeminiClientAuth:
 
         mock_client_cls.assert_called_with(
             api_key="test-key",
-            http_options={"base_url": "https://proxy.example.com/v1beta?token=secret"},
+            http_options={
+                "base_url": "https://proxy.example.com/v1beta?token=secret",
+                "timeout": 60000,
+            },
         )
         client.logger.info.assert_any_call("Using custom base URL: https://proxy.example.com")


### PR DESCRIPTION
## Summary

- Wire `request_timeout` from model configs into `google-genai` SDK's `HttpOptions.timeout` (milliseconds)
- Prevents Vertex AI requests from hanging indefinitely when the endpoint is slow or unresponsive
- Timeout values: 60s for Flash/NB2, 90s for Pro

## Root Cause

The SDK always explicitly passes `timeout=http_request.timeout` to httpx. When no timeout is configured, this resolves to `timeout=None`, which httpx interprets as "disable timeout entirely" (infinite wait) — different from omitting it (which uses the 5s client default).

## Test plan

- [x] Existing unit tests updated and passing
- [x] `ruff check` passes on changed files
- [ ] Verify with Vertex AI auth that requests now fail with timeout error instead of hanging

Fixes #31